### PR TITLE
Add MPL 2.0 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# k8sconfig-merger
+# k8stk
 Done to learn golang. Merges specified kubeconfig files into one config.
 
 Will output to stdout, or you can specify an output file. Will add a number to any duplicates found so you don't lose any contexts.

--- a/main.go
+++ b/main.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 package main
 
 import (


### PR DESCRIPTION
Updated README.md to have the new name. Added the MPL 2.0 license to all of the source code (main.go).